### PR TITLE
Makes the sensor is global

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,9 @@ cache:
 artifacts:
   - path: 'target\*.jar'
     name: Plugin
-after_test:    
+after_test:
   - ps: |
       $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
       Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-      bash codecov.sh -f "target\site\jacoco\jacoco.xml" -t 7ed90d2b-f167-4464-ada6-101b2592061e
-  
-  
+      bash codecov.sh -f "target\site\jacoco\jacoco.xml" -t 7ed90d2b-f167-4464-ada6-101b2592061e -U "-s" -A "-s"
+

--- a/src/main/java/org/sonar/generic/metrics/GenericMetricsSensor.java
+++ b/src/main/java/org/sonar/generic/metrics/GenericMetricsSensor.java
@@ -41,7 +41,7 @@ public class GenericMetricsSensor implements Sensor {
 
   @Override
   public void describe(SensorDescriptor descriptor) {
-    descriptor.name("Generic Metrics Sensor").onlyOnFileType(InputFile.Type.MAIN);
+    descriptor.name("Generic Metrics Sensor").onlyOnFileType(InputFile.Type.MAIN).global();
   }
 
   @Override

--- a/src/test/java/org/sonar/generic/metrics/TestGenericMetricsSensor.java
+++ b/src/test/java/org/sonar/generic/metrics/TestGenericMetricsSensor.java
@@ -77,11 +77,13 @@ public class TestGenericMetricsSensor {
   @Test
   public void whenDefiningShouldAppendNameAndFileTypeOnDescriptor(){
     when(descriptor.name("Generic Metrics Sensor")).thenReturn(descriptor);
+    when(descriptor.onlyOnFileType(InputFile.Type.MAIN)).thenReturn(descriptor);
 
     sensor.describe(descriptor);
 
     verify(descriptor, times(1)).name("Generic Metrics Sensor");
     verify(descriptor, times(1)).onlyOnFileType(InputFile.Type.MAIN);
+    verify(descriptor, times(1)).global();
   }
 
   @Test(expected = JSONException.class)


### PR DESCRIPTION
When scanning C# solutions with the .NET scanner, each C# project is registered as a module.
This change just makes sure the sensor is run once for the sonar project not each module


Codecov fix as per answer [community.codecov.io/t/bash-uploader-returns-error-code-on-appveyor](https://community.codecov.io/t/bash-uploader-returns-error-code-on-appveyor/1682/9)