### PR TITLE
Ignores paths starting with "//" that weren't fixed.

### DIFF
--- a/src/main/java/org/sonar/generic/metrics/GenericMetricsSensor.java
+++ b/src/main/java/org/sonar/generic/metrics/GenericMetricsSensor.java
@@ -84,6 +84,10 @@ public class GenericMetricsSensor implements Sensor {
 
   private void processFileMeasure(SensorContext context, JSONObject measure) {
     String fileName = measure.getString("file");
+    if (fileName.startsWith("//")) {
+      LOG.warn(fileName + " not found during scan");
+      return;
+    }    
     FilePredicate predicate = context.fileSystem().predicates().is(new File(fileName));
 
     String metricKey = measure.getString("metric-key");

--- a/src/test/java/org/sonar/generic/metrics/TestGenericMetricsSensor.java
+++ b/src/test/java/org/sonar/generic/metrics/TestGenericMetricsSensor.java
@@ -184,9 +184,7 @@ public class TestGenericMetricsSensor {
   @Test
   public void whenExecutingAndCanReadFileAndFileInJsonNotFoundShouldNotPublishMetrics() {
     FilePredicate filePredicate1 = mock(FilePredicate.class);
-    when(filePredicates.is(any(File.class))).thenReturn(filePredicate1);
-
-    InputFile inputFile1 = mock(InputFile.class);
+    when(filePredicates.is(any(File.class))).thenReturn(filePredicate1);    
 
     when(fileSystem.inputFile(filePredicate1)).thenReturn(null);
 
@@ -198,4 +196,20 @@ public class TestGenericMetricsSensor {
     sensor.execute(this.sensorContext);
     verify(sensorContext, times(1)).newMeasure();
   }
+
+  @Test
+  public void whenExecutingAndCanReadFileButHasFileWithFullPerforcePathShouldNotPublishMetrics() throws IOException{
+    FilePredicate filePredicate1 = mock(FilePredicate.class);
+    when(filePredicates.is(any(File.class))).thenReturn(filePredicate1);
+    InputFile inputFile1 = mock(InputFile.class);    
+    when(fileSystem.inputFile(filePredicate1)).thenReturn(inputFile1);
+
+    String json = readResourceAsString("measures3.json");
+    when(fileReader.readFile("filename")).thenReturn(json);
+
+    readMetrics();
+
+    sensor.execute(this.sensorContext);
+    verify(sensorContext, times(0)).newMeasure();
+  }  
 }

--- a/src/test/resources/measures3.json
+++ b/src/test/resources/measures3.json
@@ -1,0 +1,23 @@
+{
+	"metrics": [
+		{
+			"key": "metric1",
+			"name": "Metric 1",
+			"type": "INT",
+			"description": "Description Metric 1",
+			"direction": -1,
+			"qualitative": false,
+			"domain": "Generic Metric"
+		}
+	],
+	"file-measures": [
+		{
+			"metric-key": "metric1",
+			"file": "//full/file/path1",
+			"value": 42
+		}
+	],
+	"project-measures": [
+
+	]
+}


### PR DESCRIPTION
It causes exceptions from Sonar 8 API